### PR TITLE
update: Locator $item correct PHPDoc

### DIFF
--- a/lib/Locator.php
+++ b/lib/Locator.php
@@ -8,7 +8,7 @@ namespace bxpimple;
 class Locator
 {
 	/**
-	 * @var ServiceLocator Объект для singleton шаблона
+	 * @var Locator Объект для singleton шаблона
 	 */
 	public static $item = null;
 	/**


### PR DESCRIPTION
Сейчас `Locator $item` имеет тип `ServiceLocator `- который не определен
согласно коду в методе `init`
`self::$item = new self;`
`$item` принимает объект самого класса
предлагаю поправить PHPDoc
заодно PHPStorm и другие IDE будут довольны